### PR TITLE
Adds input validation erros with web_args/marshmallow

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -422,7 +422,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=mamba
+ignored-modules=mamba, webargs.fields
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ elasticsearch = "*"
 python-dotenv = "*"
 gunicorn = "*"
 flask-cors = "*"
+webargs = "*"
 
 [dev-packages]
 coverage = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3ab7354293810ec11f4d0d552876c0f089a1ad0ce3224e62f4ba83c5ae51ceff"
+            "sha256": "f22a627195b1ad40e6f2dd53bec086b479dbb92c3d56bab4d9d3c26d9bb54f7c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -117,13 +117,20 @@
             ],
             "version": "==1.1.0"
         },
+        "marshmallow": {
+            "hashes": [
+                "sha256:a2052f62b18f6dad520f465e437f63ab8812423975d48b9ebd30a735466e782a",
+                "sha256:e1b79eb3b815b49918c64114dda691b8767b48a1f66dd1d8c0cd5842b74257c2"
+            ],
+            "version": "==2.16.3"
+        },
         "python-dotenv": {
             "hashes": [
-                "sha256:122290a38ece9fe4f162dc7c95cae3357b983505830a154d3c98ef7f6c6cea77",
-                "sha256:4a205787bc829233de2a823aa328e44fd9996fedb954989a21f1fc67c13d7a77"
+                "sha256:4f3582904d08dac5ab4c9aa44cb17ce056c9a35e585cfda6183d80054d247307",
+                "sha256:cb8cd327109898c7725f76c5256a081e8a9efe72ebbf127f8d1221ceb7f38bf2"
             ],
             "index": "pypi",
-            "version": "==0.9.1"
+            "version": "==0.10.0"
         },
         "pytz": {
             "hashes": [
@@ -145,6 +152,14 @@
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
             "version": "==1.24.1"
+        },
+        "webargs": {
+            "hashes": [
+                "sha256:39f38c314755e152ae06f7cbc4f9ed9cd2017f6226c32f0fb0bb1310b787dbbe",
+                "sha256:fc8f8365d7d9edf2e44bbac98b925d737ad68639edf728d9f517aae1eb2d20f4"
+            ],
+            "index": "pypi",
+            "version": "==4.1.3"
         },
         "werkzeug": {
             "hashes": [

--- a/application/controllers/artifacts_controller.py
+++ b/application/controllers/artifacts_controller.py
@@ -71,6 +71,17 @@ def update_params():
     parser.add_argument("tags", action="append", default=[])
     return parser.parse_args()
 
+def update_args():
+    return {
+        "id": fields.UUID(required=True, load_from='object_id', location='view_args'),
+        "tags": fields.List(fields.String(), missing=[]),
+        "file_url": fields.Function(deserialize=validate_file_name)
+    }
+
+def validate_file_name(filename):
+    if not allowed_file(filename):
+        raise ValidationError('Errornous file_url')
+    return filename
 
 def add_tags_params():
     """ Defines and validates add tags params """
@@ -150,10 +161,12 @@ class ArtifactsController(ApplicationController):
 
     def update(self, object_id):
         "Logic for updating an artifact"
-
-        params = update_params()
+        print(request)
+        params = parser.parse(update_args(), request)
+        artifact_id = str(params.pop('id'))
+        # params = update_params()
         try:
-            artifact = Artifact.find(object_id)
+            artifact = Artifact.find(artifact_id)
             artifact.update(params)
             return '', 204
         except NotFound:

--- a/specs/factories/elasticsearch.py
+++ b/specs/factories/elasticsearch.py
@@ -2,7 +2,7 @@
 
 def es_get_response():
     """ Creates an example body for a get request """
-    return {"_id": "1",
+    return {"_id": "dc5434f4-1239-41b2-87a1-c8df49f94ab2",
             "_type": "image",
             "_source": {"tags": ["class_diagram", ""],
                         "created_at": "today",
@@ -15,7 +15,7 @@ def es_search_response():
     return {"hits": {"total": 12, "max_score": 1.0, "hits": [
         {"_index": "artifact",
          "_type": "image",
-         "_id": 1,
+         "_id": 'dc5434f4-1239-41b2-87a1-c8df49f94ab2',
          "_score": 1.0,
          "_source": {
              "created_at": "today",
@@ -25,7 +25,7 @@ def es_search_response():
              "file_date": "today"}},
         {"_index": "artifact",
          "_type": "image",
-         "_id": 1,
+         "_id": 'dc5434f4-1239-41b2-87a1-c8df49f94ab2',
          "_score": 0.5,
          "_source": {
              "created_at": "yesterday",

--- a/specs/factories/elasticsearch.py
+++ b/specs/factories/elasticsearch.py
@@ -1,8 +1,9 @@
 """ Defines mocked elasticsearch responses """
+from specs.factories.uuid_fixture import get_uuid
 
 def es_get_response():
     """ Creates an example body for a get request """
-    return {"_id": "dc5434f4-1239-41b2-87a1-c8df49f94ab2",
+    return {"_id": f"{get_uuid(0)}",
             "_type": "image",
             "_source": {"tags": ["class_diagram", ""],
                         "created_at": "today",
@@ -15,7 +16,7 @@ def es_search_response():
     return {"hits": {"total": 12, "max_score": 1.0, "hits": [
         {"_index": "artifact",
          "_type": "image",
-         "_id": 'dc5434f4-1239-41b2-87a1-c8df49f94ab2',
+         "_id": f"{get_uuid(0)}",
          "_score": 1.0,
          "_source": {
              "created_at": "today",
@@ -25,7 +26,7 @@ def es_search_response():
              "file_date": "today"}},
         {"_index": "artifact",
          "_type": "image",
-         "_id": 'dc5434f4-1239-41b2-87a1-c8df49f94ab2',
+         "_id": f"{get_uuid(0)}",
          "_score": 0.5,
          "_source": {
              "created_at": "yesterday",

--- a/specs/factories/uuid_fixture.py
+++ b/specs/factories/uuid_fixture.py
@@ -1,0 +1,3 @@
+uuids = ['dc5434f4-1239-41b2-87a1-c8df49f94ab2']
+def get_uuid(index):
+    return uuids[index]

--- a/specs/factories/uuid_fixture.py
+++ b/specs/factories/uuid_fixture.py
@@ -1,3 +1,6 @@
-uuids = ['dc5434f4-1239-41b2-87a1-c8df49f94ab2']
+"""Manages uuids for tests in one file"""
+UUIDS = ['dc5434f4-1239-41b2-87a1-c8df49f94ab2']
 def get_uuid(index):
-    return uuids[index]
+    """get a uuid, each index will be a new id.
+    But always the same with each index"""
+    return UUIDS[index]


### PR DESCRIPTION
Input validation with reqparser is deprecated so I swapped it to web_args which uses marshmallow under the hood.

Also we know have 422 errorcodes when the input is not valid and passed ids have to be uuids :)