### PR TITLE
Multi Tagging

### DIFF
--- a/application/routes.py
+++ b/application/routes.py
@@ -16,7 +16,6 @@ def create_routes(api):
     add_resource(api, '/images', ArtifactsController)
     add_resource(api, '/teams', TeamsController)
     add_resource(api, '/presentations', PresentationsController, only="create")
-    add_method(api, '/images/<object_id>/tags', "add_tags",
-               TagsController, method="post")
-    add_method(api, "/tags/suggested", "suggested_tags",
-               TagsController, method="get")
+    add_method(api, '/images/<object_id>/tags', "add_tags", TagsController, method="post")
+    add_method(api, '/tags', "multi_tagging", TagsController, method="post")
+    add_method(api, "/tags/suggested", "suggested_tags", TagsController, method="get")

--- a/application/validators/tags_validator.py
+++ b/application/validators/tags_validator.py
@@ -2,8 +2,16 @@
 
 from webargs import fields
 
+def multi_tagging_args():
+    """ Defines and validates params for multi_tagging """
+    return {
+        "ids": fields.List(fields.UUID(), required=True),
+        "tags": fields.List(fields.String(), missing=[]),
+    }
+
+
 def add_tags_args():
-    """Defines and validates params for add_tags"""
+    """ Defines and validates params for add_tags """
     return {
         "id": fields.UUID(required=True, load_from='object_id', location='view_args'),
         "tags": fields.List(fields.String(), missing=[]),


### PR DESCRIPTION
This PR enables support for multi-tagging.
Which means: I can set tags for a chunk of images.

My suggested route is `POST /tags` with `{ "ids": [...], "tags": [...] }` 
Please feel free to suggest a better route.

Regarding the algorithm it works more like a PUT:
The set of tags you send over this route will consequentially be the set of tags all the images have in common.

So if you have two images tagged with `[a, b, c]` and `[a, b, d]` and I send `[a]` as the new multi tags for those images the resulting set of tags will be `[a, c]` and `[a, d]` since I stated `[a]` as the **total set of tags the images should have in common**.

Another approach would be to make separate delete and create routes for single multi tags. Maybe worth a thought, too.