### PR TITLE
Refactor suggested tags

### DIFF
--- a/application/controllers/tags_controller.py
+++ b/application/controllers/tags_controller.py
@@ -3,13 +3,13 @@ Handles all logic of the artefacts api
 """
 from webargs.flaskparser import use_args
 
-from application.models.elastic.elastic_artifact import ElasticArtifact
 from .application_controller import ApplicationController
 from ..error_handling.es_connection import check_es_connection
 from ..models import Artifact, Team
 from ..models.artifact_builder import ArtifactBuilder
 from ..validators import tags_validator
 from ..tagging import tag_suggestions
+from ..responders import no_content
 
 class TagsController(ApplicationController):
     """ Controller for Artifacts """
@@ -29,7 +29,7 @@ class TagsController(ApplicationController):
             new_list = existing_tags + list(set(params["tags"]) - set(existing_tags))
 
             builder.update_with(tags=new_list)
-            return '', 204
+            return no_content()
         except Artifact.DoesNotExist:
             return {"error": "not found"}, 404
 
@@ -39,6 +39,4 @@ class TagsController(ApplicationController):
         current_tags = params['tags']
         team = Team.find(params['team_id'])
         current_tags = [tag for tag in current_tags if tag != ""]
-        return tag_suggestions.find_tags(team, params['limit'], current_tags)
-
-
+        return {'tags': tag_suggestions.find_tags(team, params['limit'], current_tags)}, 200

--- a/application/controllers/tags_controller.py
+++ b/application/controllers/tags_controller.py
@@ -6,10 +6,10 @@ from webargs.flaskparser import use_args
 from application.models.elastic.elastic_artifact import ElasticArtifact
 from .application_controller import ApplicationController
 from ..error_handling.es_connection import check_es_connection
-from ..models import Artifact
+from ..models import Artifact, Team
 from ..models.artifact_builder import ArtifactBuilder
 from ..validators import tags_validator
-
+from ..tagging import tag_suggestions
 
 class TagsController(ApplicationController):
     """ Controller for Artifacts """
@@ -37,46 +37,8 @@ class TagsController(ApplicationController):
     def suggested_tags(self, params):
         """ Takes an array of tags and suggests tags based on that """
         current_tags = params['tags']
-
+        team = Team.find(params['team_id'])
         current_tags = [tag for tag in current_tags if tag != ""]
+        return tag_suggestions.find_tags(team, params['limit'], current_tags)
 
-        # all of this will be refactored in favor of a proper frequent
-        # itemset mining algorithm, probably charm
-        all_records = ElasticArtifact.all(create_objects=False) or []
-        tag_frequencies = {}
-        current_tags_frequency = 0
 
-        for record in all_records:
-            if (set(current_tags).intersection(set(record["tags"]))
-                    and set(record["tags"]).difference(set(current_tags))):
-                current_tags_frequency += 1
-                for tag in set(record["tags"]).difference(set(current_tags)):
-                    if tag in tag_frequencies.keys():
-                        tag_frequencies[tag] += 1
-                    else:
-                        tag_frequencies[tag] = 1
-
-        min_support_frequencies = {key: value for (key, value) in tag_frequencies.items()
-                                   if value / current_tags_frequency >= params['min_support']}
-        sorted_frequencies = sorted(min_support_frequencies.items(),
-                                    key=lambda kv: kv[1], reverse=True)[:params['limit']]
-        sorted_tags = [frequency[0] for frequency in sorted_frequencies]
-
-        if not sorted_tags:
-            return {"tags": self.most_frequent_tags(all_records, params['limit'])}, 200
-        return {"tags": sorted_tags}, 200
-
-    @staticmethod
-    def most_frequent_tags(records, limit):
-        """returns the most frequently used tags in a given list of artifacts"""
-        tag_frequencies = {}
-        for record in records:
-            for tag in record["tags"]:
-                if tag in tag_frequencies.keys():
-                    tag_frequencies[tag] += 1
-                else:
-                    tag_frequencies[tag] = 1
-        sorted_frequencies = sorted(tag_frequencies.items(),
-                                    key=lambda kv: kv[1], reverse=True)[:limit]
-        sorted_tags = [frequency[0] for frequency in sorted_frequencies]
-        return sorted_tags

--- a/application/tagging/tag_suggestions.py
+++ b/application/tagging/tag_suggestions.py
@@ -1,0 +1,76 @@
+from neomodel import db
+
+
+def find_tags(team, limit, tags=None):
+    """ find tags in a given team
+    :param team: instance of Team model, only tags used in that team will be returned
+    :param limit: how many tags to fetch
+    :param tags: refines the search to favor related tags
+    :return: list of tag names eg. ['cat', 'blue', 'sky']
+    """
+    sorted_tags = tags_by_team_and_tags(team, limit, tags) if tags else tags_by_team(team, limit)
+    return sorted_tags
+
+
+def tags_by_team(team, limit, excluded_tags=None):
+    query = _collect_artifacts_query() + _collect_tags_query()
+    result, meta = team.cypher(query, {'limit': limit, 'tags': excluded_tags or []})
+    tags = [sorted_tag[0] for sorted_tag in result]
+    return tags
+
+
+def _collect_artifacts_query():
+    return (
+        'MATCH (team) WHERE id(team)={self} '
+        'MATCH (team)-[:UPLOADED]->(artifact) '
+        'WITH collect(artifact) AS artifacts, count(artifact) AS max_count '
+    )
+
+
+def tags_by_team_and_tags(team, limit, tags):
+    query = _collect_artifacts_with_tags_query() + _collect_tags_query()
+    tag_dictionary = {}
+    for i in range(1, len(tags) + 1):
+        results, meta = db.cypher_query(query, {'tags': tags, 'match_count': 1, 'limit': limit, 'team_id': team.id})
+        _add_to_dictionary(results, tag_dictionary)
+
+    sorted_results = sorted(tag_dictionary.items(),
+                            key=lambda collection: collection[1], reverse=True)[:limit]
+
+    sorted_tags = [sorted_tag[0] for sorted_tag in sorted_results]
+    # If there aren't enough related tags for the given tag(s) we fill it up with not related_tags
+    if len(sorted_tags) < limit:
+        additional_tags = tags_by_team(team, limit - len(sorted_tags), excluded_tags=(tags + sorted_tags))
+        # additional_tags are always weighted less then related_tags
+        sorted_tags += additional_tags
+
+    return sorted_tags
+
+
+def _collect_artifacts_with_tags_query():
+    return (
+        'MATCH (team) WHERE id(team)={team_id} '
+        'MATCH (team)-[:UPLOADED]->(artifact:Artifact), (tag:Tag) '
+        'WHERE tag.name IN {tags} AND (size((artifact)-[:TAGGED_WITH]->(tag)) >= {match_count}) '
+        'WITH collect(artifact) AS artifacts, count(artifact) AS max_count '
+    )
+
+
+def _collect_tags_query():
+    return (
+        'UNWIND artifacts AS artifact '
+        'MATCH (artifact)-[:TAGGED_WITH]->(tag) '
+        'WHERE NOT tag.name IN {tags} '
+        'WITH tag.name AS tag_name, (toFloat(count(artifact))/max_count) AS p '
+        'WITH tag_name, p, (1.0 - p) AS p_neg '
+        'RETURN tag_name, ((-p * log(p) / log(2)) - (p_neg * log(p_neg) / log(2))) AS entropy '
+        'ORDER BY entropy DESC '
+        'LIMIT {limit}'
+    )
+
+
+def _add_to_dictionary(results, dictionary):
+    for item in results:
+        if item[1] > dictionary.get(item[0], 0.0):
+            dictionary[item[0]] = item[1]
+

--- a/application/validators/tags_validator.py
+++ b/application/validators/tags_validator.py
@@ -14,6 +14,7 @@ def add_tags_args():
 def suggested_tags_args():
     """ Defines and validates suggested tags params """
     return {
+        "team_id": fields.UUID(required=True),
         "tags": fields.List(fields.String(), missing=[]),
         "min_support": fields.Number(missing=0.25, validate=lambda val: val <= 1),
         "limit": fields.Integer(missing=3)

--- a/specs/factories/artifact_factory.py
+++ b/specs/factories/artifact_factory.py
@@ -10,6 +10,10 @@ class ArtifactFactory:
             builder = ArtifactBuilder.for_artifact(artifact)
             builder.update_with(user_tags=user_tags)
 
+        return artifact
+
     @classmethod
-    def build_artifact(cls, id_='abc', file_url='abc'):
-        return Artifact(id_=id_, file_url=file_url)
+    def build_artifact(cls, **kwargs):
+        if 'file_url' not in kwargs:
+            kwargs["file_url"] = 'abc'
+        return Artifact(**kwargs)


### PR DESCRIPTION
Refactor suggested tags algorithm:
- it is team-based
- it is calculated entirely in neo4j
- it uses entropy function to determine order.
  - e.g. tags that used in exactly half of the artifacts are most important since they split
    they are best for separating the artifact from others, while tags that are used on a lot of artifacts
    or tags that are rarely used are less important.


