### PR TITLE
NLTK download in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /src
 RUN poetry config settings.virtualenvs.create false
 RUN poetry install --no-dev
 
+# text processing resources
+RUN poetry run python -c "import nltk; nltk.download('all')"
+
 EXPOSE 5000
 
 CMD [ "./start-gunicorn.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
 FROM python:3.7-alpine
 
+WORKDIR /src
+
 RUN apk add libffi-dev build-base
 
 # pillow dependencies
 RUN apk add jpeg-dev zlib-dev
 
+COPY pyproject.toml .
+COPY poetry.lock .
+
 RUN pip install poetry
 
-COPY . /src
-WORKDIR /src
 RUN poetry config settings.virtualenvs.create false
 RUN poetry install --no-dev
 
 # text processing resources
-RUN poetry run python -c "import nltk; nltk.download('all')"
+RUN python -c "import nltk; nltk.download('all')"
+
+COPY . .
 
 EXPOSE 5000
 


### PR DESCRIPTION
Since we are now testing the search in our e2e tests we need the nltk data in all our images that are tested with cypress. Actually adding it, in general, is nice because we will not have to worry about if it is installed or not because it's baked into the image.