### PR TITLE
Refactor Artifact creation.

### DIFF
--- a/application/artifacts/artifact_connector.py
+++ b/application/artifacts/artifact_connector.py
@@ -1,18 +1,17 @@
-"""Abstracting Sync of Neo and Elastic"""
-
 from application.artifacts.artifact import Artifact
+from application.artifacts.property_builder import PropertyBuilder
 from application.artifacts.tags.tag import Tag
 from application.teams.team import Team
 from application.users.user import User
-from application.artifacts.property_builder import PropertyBuilder
 
 
-class ArtifactBuilder:
-    """This class helps with building Artifacts"""
+class ArtifactConnector:
+    """This class helps with building the database connections
+    for Artifact model objects."""
 
     @classmethod
     def for_artifact(cls, neo):
-        """Create an ArtifactBuilder for a specific Artifact"""
+        """Create an ArtifactConnector for a specific Artifact"""
         builder = cls()
         builder.neo = neo
         return builder
@@ -21,7 +20,7 @@ class ArtifactBuilder:
         self.neo = None
 
     def build_with(self, **properties):
-        """builds self.neo and saves it"""
+        """builds a new Artifact with correct connections and saves it"""
         props = PropertyBuilder(**properties)
         neo_properties = props.node_properties
         self.neo = Artifact(**neo_properties).save()
@@ -37,7 +36,7 @@ class ArtifactBuilder:
             self._connect_relation(self.neo.user, User.find(props["user_id"]))
 
     def save(self):
-        """Save both models"""
+        """Saves the referenced artifact model"""
         self.neo.save()
 
     def _add_tags_to_neo(self, new_tags, tag_relation, override=False):
@@ -64,9 +63,9 @@ class ArtifactBuilder:
         self.neo.update(**neo_properties)
 
     @classmethod
-    def find(cls, uid, force=True):  # pylint: disable= invalid-name
-        """Finds Artifact and creates instances"""
-        artifact = ArtifactBuilder()
+    def find(cls, uid, force=True):
+        """Finds an artifact and saves it to this Connector"""
+        artifact = ArtifactConnector()
         artifact.neo = Artifact.find(uid, force=force)
         return artifact
 

--- a/application/artifacts/artifact_creation.py
+++ b/application/artifacts/artifact_creation.py
@@ -1,0 +1,115 @@
+"""Abstracting Sync of Neo and Elastic"""
+import datetime
+import os
+import uuid
+
+import werkzeug
+from PIL import Image
+from flask import current_app
+
+from application.artifacts.artifact_connector import ArtifactConnector
+from application.artifacts.image_recognition import ImageRecognizer
+
+
+class ImageResizer:
+    """Saves resized versions of an image to disk"""
+
+    widths = [320, 480, 640, 750, 1080]
+
+    def __init__(self, file_path):
+        self.image = Image.open(file_path)
+        self.original_file_name = file_path.split("/")[-1]
+
+    def save_sizes(self):
+        """Saves resized image for all defined widths"""
+        for width in self.widths:
+            height = self._calculate_height(width)
+            resized_image = self.image.resize((width, height), Image.ANTIALIAS)
+            resized_image.save(self._generate_file_path(width))
+            resized_image.close()
+
+    def _generate_file_path(self, width):
+        file_name = self._generate_file_name(width)
+        return os.path.join(current_app.config["UPLOAD_FOLDER"], file_name)
+
+    def _generate_file_name(self, width):
+        """Generate filename for a resized image of given width"""
+        [prefix, suffix] = self.original_file_name.rsplit(".", 1)
+        filename = f"{prefix}_{width}w.{suffix}"
+        return filename
+
+    def _calculate_height(self, width):
+        """Calculate height of resized image with given width"""
+        width_ratio = width / self.image.size[0]
+        height = int(self.image.size[1] * width_ratio)
+        return height
+
+
+class FileSaver:
+    """Saves a file to disk and creates according metadata"""
+
+    def __init__(self, file):
+        self.file = file
+        self.file_date = None
+        self.file_name = None
+        self.file_path = None
+
+    def save(self):
+        """Saves an artifact to disk."""
+        self._create_metadata()
+        self._save_file()
+
+    def get_metadata(self):
+        """Get Metadata as hash (file_url and file_date)"""
+        return {"file_url": self.file_name, "file_date": self.file_date}
+
+    def _create_metadata(self):
+        self.file_name = self._generate_filename()
+        self.file_date = datetime.datetime.now()
+        self.file_path = self._file_path()
+
+    def _save_file(self):
+        self.file.save(self.file_path)
+        self.file.close()
+
+    def _file_path(self):
+        return os.path.join(current_app.config["UPLOAD_FOLDER"], self.file_name)
+
+    def _generate_filename(self):
+        return str(uuid.uuid4()) + "_" + werkzeug.utils.secure_filename(self.file.filename)
+
+
+class ArtifactCreator:
+    """Creates an artifact by file, owner_id and team_id.
+    The file is saved and resized before creating the artifact in the database.
+    All optional parameters are passed to the ArtifactConnector.
+    The file has to be a werkzeug.datastructures.FileStorage object."""
+
+    def __init__(self, file, owner_id, team_id, **optional):
+        self.file = file
+        self.owner_id = owner_id
+        self.team_id = team_id
+        self.additional_params = optional
+
+    def create_artifact(self):
+        """ Starts the creation process. """
+        file_metadata = self._upload_file()
+        artifact = self._save_to_db(file_metadata)
+        ImageRecognizer.auto_add_tags(artifact)
+        return artifact
+
+    def _save_to_db(self, file_metadata):
+        artifact = ArtifactConnector().build_with(
+            user_id=self.owner_id, team_id=self.team_id, **{**self.additional_params, **file_metadata}
+        )
+        artifact.save()
+        return artifact
+
+    def _upload_file(self):
+        file_saver = FileSaver(self.file)
+        file_saver.save()
+
+        image_resizer = ImageResizer(file_saver.file_path)
+        image_resizer.save_sizes()
+
+        return file_saver.get_metadata()

--- a/application/artifacts/artifacts_view.py
+++ b/application/artifacts/artifacts_view.py
@@ -2,23 +2,19 @@
 Handles all logic of the artifacts api
 """
 import logging
-import datetime
 import os
-import uuid
 from pathlib import Path
-from PIL import Image
 
-import werkzeug
 from flask import current_app, abort
 from flask_apispec import MethodResource, use_kwargs, marshal_with
 from flask_jwt_extended import jwt_optional, get_jwt_identity, jwt_required
 from flask_socketio import emit
 
 from application.artifacts import artifacts_validator
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
+from application.artifacts.artifact_creation import ArtifactCreator
 from application.artifacts.artifact_schema import ARTIFACT_SCHEMA, ARTIFACTS_SCHEMA
 from application.artifacts.elastic import ElasticSearcher
-from application.artifacts.image_recognition import ImageRecognizer
 from application.artifacts.synonyms import SynonymGenerator
 from application.errors import check_es_connection
 from application.extensions import socketio
@@ -93,7 +89,7 @@ class ArtifactView(MethodResource):
         """Logic for updating an artifact"""
         try:
             artifact = Artifact.find_by(id_=params.pop("id"))
-            builder = ArtifactBuilder.for_artifact(artifact)
+            builder = ArtifactConnector.for_artifact(artifact)
             builder.update_with(**params)
             return no_content()
         except Artifact.DoesNotExist:
@@ -142,21 +138,10 @@ class ArtifactsView(MethodResource):
     @marshal_with(ARTIFACT_SCHEMA)
     def post(self, **params):
         """Logic for creating an artifact"""
-        metadata = self._upload_file(params)
-        self._add_user_to_params(metadata)
-        artifact = self._create_artifact(params, metadata)
-        ImageRecognizer.auto_add_tags(artifact)
-        return artifact
-
-    def _add_user_to_params(self, params):
-        user_id = get_jwt_identity()
-        params["user_id"] = user_id
-
-    def _create_artifact(self, params, metadata):
-        params.update(metadata)
-        artifact = ArtifactBuilder().build_with(**params)
-        artifact.save()
-        return artifact
+        creator = ArtifactCreator(
+            params.pop("file"), owner_id=get_jwt_identity(), team_id=params.pop("team_id"), **params
+        )
+        return creator.create_artifact()
 
     @use_kwargs(artifacts_validator.update_many_args())
     @marshal_with(None, 204)
@@ -167,86 +152,9 @@ class ArtifactsView(MethodResource):
             id = update_data.pop("id")
             try:
                 artifact = Artifact.find_by(id_=id)
-                builder = ArtifactBuilder.for_artifact(artifact)
+                builder = ArtifactConnector.for_artifact(artifact)
                 builder.update_with(override_tags=False, **update_data)
             except Artifact.DoesNotExist:
                 return abort(404, f"failed at <{id}>: not found")
 
         return no_content()
-
-    def _upload_file(self, params):
-        file_saver = FileSaver(params["file"])
-        file_saver.save()
-
-        image_resizer = ImageResizer(file_saver.file_path)
-        image_resizer.save_sizes()
-
-        return file_saver.get_metadata()
-
-
-class ImageResizer:  # pylint:disable=too-few-public-methods
-    """Saves resized versions of an image to disk"""
-
-    widths = [320, 480, 640, 750, 1080]
-
-    def __init__(self, file_path):
-        self.image = Image.open(file_path)
-        self.original_file_name = file_path.split("/")[-1]
-
-    def save_sizes(self):
-        """Saves resized image for all defined widths"""
-        for width in self.widths:
-            height = self._calculate_height(width)
-            resized_image = self.image.resize((width, height), Image.ANTIALIAS)
-            resized_image.save(self._generate_file_path(width))
-            resized_image.close()
-
-    def _generate_file_path(self, width):
-        file_name = self._generate_file_name(width)
-        return os.path.join(current_app.config["UPLOAD_FOLDER"], file_name)
-
-    def _generate_file_name(self, width):
-        """Generate filename for a resized image of given width"""
-        [prefix, suffix] = self.original_file_name.rsplit(".", 1)
-        filename = f"{prefix}_{width}w.{suffix}"
-        return filename
-
-    def _calculate_height(self, width):
-        """Calculate height of resized image with given width"""
-        width_ratio = width / self.image.size[0]
-        height = int(self.image.size[1] * width_ratio)
-        return height
-
-
-class FileSaver:
-    """Saves a file to disk and creates according metadata"""
-
-    def __init__(self, file):
-        self.file = file
-        self.file_date = None
-        self.file_name = None
-        self.file_path = None
-
-    def save(self):
-        """Saves an artifact to disk."""
-        self._create_metadata()
-        self._save_file()
-
-    def get_metadata(self):
-        """Get Metadata as hash (file_url and file_date)"""
-        return {"file_url": self.file_name, "file_date": self.file_date}
-
-    def _create_metadata(self):
-        self.file_name = self._generate_filename()
-        self.file_date = datetime.datetime.now()
-        self.file_path = self._file_path()
-
-    def _save_file(self):
-        self.file.save(self.file_path)
-        self.file.close()
-
-    def _file_path(self):
-        return os.path.join(current_app.config["UPLOAD_FOLDER"], self.file_name)
-
-    def _generate_filename(self):
-        return str(uuid.uuid4()) + "_" + werkzeug.utils.secure_filename(self.file.filename)

--- a/application/artifacts/image_recognition.py
+++ b/application/artifacts/image_recognition.py
@@ -4,7 +4,7 @@ from eventlet import spawn_n
 from flask import copy_current_request_context
 from flask import current_app
 
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
 from application.artifacts.artifact_schema import ArtifactSchema
 
 
@@ -78,5 +78,5 @@ class ImageRecognizer:
     @classmethod
     def add_tags_artifact(cls, artifact, label_annotations, text_annotations):
         """Adds annotations to an artifact"""
-        builder = ArtifactBuilder.for_artifact(artifact)
+        builder = ArtifactConnector.for_artifact(artifact)
         builder.update_with(override_tags=False, label_tags=label_annotations, text_tags=text_annotations)

--- a/application/artifacts/tags/tags_view.py
+++ b/application/artifacts/tags/tags_view.py
@@ -9,7 +9,7 @@ from marshmallow import fields, Schema
 from application.errors import check_es_connection
 from application.artifacts.artifact import Artifact
 from application.teams.team import Team
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
 from application.responders import no_content
 from application.artifacts.tags import tag_suggestions, tags_validator
 
@@ -31,7 +31,7 @@ class TagsView(MethodResource):
         """Adds tags to an existing artifact"""
         try:
             artifact = Artifact.find_by(id_=params.pop("id"))
-            builder = ArtifactBuilder.for_artifact(artifact)
+            builder = ArtifactConnector.for_artifact(artifact)
             existing_tags = artifact.tags or []
 
             new_list = existing_tags + list(set(params["tags"]) - set(existing_tags))

--- a/specs/factories/artifact_factory.py
+++ b/specs/factories/artifact_factory.py
@@ -1,5 +1,5 @@
 from application.artifacts.artifact import Artifact
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
 
 
 class ArtifactFactory:
@@ -8,7 +8,7 @@ class ArtifactFactory:
         artifact = cls.build_artifact(*args, **kwargs).save()
 
         if user_tags:
-            builder = ArtifactBuilder.for_artifact(artifact)
+            builder = ArtifactConnector.for_artifact(artifact)
             builder.update_with(user_tags=user_tags)
 
         return artifact

--- a/specs/factories/image_recognition.py
+++ b/specs/factories/image_recognition.py
@@ -1,7 +1,9 @@
 """ Defines mocked Google Cloud Vision API responses """
 from unittest.mock import patch
 
-mock_image_recognition = patch("application.artifacts.artifacts_view.ImageRecognizer.auto_add_tags", return_value=None)
+mock_image_recognition = patch(
+    "application.artifacts.artifact_creation.ImageRecognizer.auto_add_tags", return_value=None
+)
 
 
 def vision_api_response():

--- a/specs/models/relations/artifact_wrapper_spec.py
+++ b/specs/models/relations/artifact_wrapper_spec.py
@@ -1,11 +1,11 @@
-""" Test the ArtifactBuilder class. Currently it's more of a wrapper than a builder sadly
+""" Test the ArtifactConnector class. Currently it's more of a wrapper than a builder sadly
     #refactor soon"""
 from expects import expect, be_none, be_a, equal, contain
 from mamba import description, before, after, it, context
 from neomodel import db
 
 from application.artifacts.artifact import Artifact
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
 from specs.spec_helpers import Context
 
 with description("Artifact Wrapper") as self:
@@ -19,7 +19,7 @@ with description("Artifact Wrapper") as self:
 
     with description("Building"):
         with before.each:
-            self.artifact = ArtifactBuilder()
+            self.artifact = ArtifactConnector()
             self.artifact.build_with(file_url="asdf", type="image")
 
         with it("creates a neo artifact"):
@@ -29,7 +29,7 @@ with description("Artifact Wrapper") as self:
     with description("Save"):
         with context("without tags"):
             with before.each:
-                self.artifact = ArtifactBuilder()
+                self.artifact = ArtifactConnector()
                 self.artifact.build_with(file_url="asdf", type="image")
                 self.artifact.save()
 
@@ -38,7 +38,7 @@ with description("Artifact Wrapper") as self:
 
         with context("with tags"):
             with before.each:
-                self.artifact = ArtifactBuilder()
+                self.artifact = ArtifactConnector()
                 self.artifact.build_with(file_url="asdf", type="image", user_tags=["a", "s", "d", "f"])
                 self.artifact.save()
 
@@ -48,7 +48,7 @@ with description("Artifact Wrapper") as self:
     with description("update"):
         with context("file_url"):
             with before.each:
-                self.artifact = ArtifactBuilder()
+                self.artifact = ArtifactConnector()
                 self.artifact.build_with(file_url="asdf", type="image")
                 self.artifact.save()
                 self.artifact.update_with(file_url="blub")
@@ -59,7 +59,7 @@ with description("Artifact Wrapper") as self:
 
         with context("tags"):
             with before.each:
-                self.artifact = ArtifactBuilder()
+                self.artifact = ArtifactConnector()
                 self.artifact.build_with(file_url="asdf", type="image")
                 self.artifact.save()
                 self.artifact.update_with(

--- a/specs/recognition/image_recognition_spec.py
+++ b/specs/recognition/image_recognition_spec.py
@@ -3,7 +3,7 @@ from doublex_expects import have_been_called
 from expects import expect, contain
 from mamba import description, before, it
 
-from application.artifacts.artifact_builder import ArtifactBuilder
+from application.artifacts.artifact_connector import ArtifactConnector
 from application.artifacts.image_recognition import ImageRecognizer
 from specs.factories.image_recognition import vision_api_response
 from specs.spec_helpers import Context
@@ -12,7 +12,7 @@ with description("image recognition called during create") as self:
     with before.each:
         self.context = Context()
         self.recognizer = ImageRecognizer
-        builder = ArtifactBuilder()
+        builder = ArtifactConnector()
         self.artifact = builder.build_with(file_url="files/test.jpg", tags=["test"], user_tags=["test"])
         self.recognizer._call_google_api = method_returning(vision_api_response())
 


### PR DESCRIPTION
I''ve extracted all the creation logic into a seperate file. Which will hopefully enable me to reuse that logic when downloading files from google drive, without sending actual POST requests to /images.

I also renamed the ArtifactBuilder to ArtifactConnector so it doesn't get confused with ArtifactCreator. If there are any other naming suggestions. I'm very open to them. Seems at least slightly confusing to me as well still.